### PR TITLE
v4.2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ bundle-stats.json
 /.github
 /coverage
 AGENTS.md
+
+# Release packages
+/releases

--- a/extension/manifest.firefox.json
+++ b/extension/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Power-Toolkit for Power Apps",
-    "version": "4.2.1",
+    "version": "4.2.2",
     "description": "A client-side toolkit for Power Apps and Dynamics365 developers to inspect, debug, and manipulate data.",
     "author": "Mohammed Khawatme",
     "icons": {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Power-Toolkit for Power Apps",
-    "version": "4.2.1",
+    "version": "4.2.2",
     "description": "A client-side toolkit for Power Apps and Dynamics365 developers to inspect, debug, and manipulate data.",
     "author": "Mohammed Khawatme",
     "icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "power-toolkit",
-    "version": "4.2.1",
+    "version": "4.2.2",
     "type": "module",
     "description": "A comprehensive, client-side toolkit for Power Apps Model-Driven App developers.",
     "private": true,
@@ -16,8 +16,7 @@
         "build": "node ./node_modules/webpack/bin/webpack.js --mode=production",
         "build:firefox": "node ./node_modules/webpack/bin/webpack.js --mode=production --env browser=firefox",
         "build:all": "npm run build && npm run build:firefox",
-        "package:firefox": "npm run build:firefox && cd dist-firefox/extension && web-ext build --overwrite-dest",
-        "package:source": "git archive -o power-toolkit-source.zip HEAD",
+        "package:all": "node scripts/package-all.cjs",
         "lint": "eslint src/**/*.js",
         "analyze": "npm run build && start bundle-report.html",
         "test": "vitest run",

--- a/scripts/package-all.cjs
+++ b/scripts/package-all.cjs
@@ -1,0 +1,75 @@
+'use strict';
+/**
+ * @file package-full.cjs
+ * @description Builds Chrome & Firefox extensions and packages each into a
+ *   versioned ZIP, then archives the source tree.
+ *
+ * Outputs (in releases/ — git-ignored):
+ *   chrome-v<version>.zip    — contents of dist/extension/
+ *   firefox-v<version>.zip   — contents of dist-firefox/extension/
+ *   source-v<version>.zip    — full source via `git archive`
+ */
+
+const { execSync, spawnSync } = require('child_process');
+const { readFileSync, mkdirSync } = require('fs');
+const path = require('path');
+
+const rootDir = path.resolve(__dirname, '..');
+const pkg = JSON.parse(readFileSync(path.join(rootDir, 'package.json'), 'utf8'));
+const version = `v${pkg.version}`;
+
+const releasesDir = path.join(rootDir, 'releases');
+mkdirSync(releasesDir, { recursive: true });
+
+const chromeZip = path.join(releasesDir, `chrome-${version}.zip`);
+const firefoxZip = path.join(releasesDir, `firefox-${version}.zip`);
+const sourceZip = path.join(releasesDir, `source-${version}.zip`);
+
+const opts = { cwd: rootDir, stdio: 'inherit' };
+
+console.log(`\n📦  Power-Toolkit Full Package — ${version}\n`);
+
+// ── 1. Build both targets ─────────────────────────────────────────────────────
+console.log('⚙️   Building Chrome & Firefox…');
+execSync('npm run build:all', opts);
+
+// ── 2. Chrome extension ───────────────────────────────────────────────────────
+console.log(`\n📦  Creating chrome-${version}.zip…`);
+zipDir(path.join(rootDir, 'dist', 'extension'), chromeZip);
+
+// ── 3. Firefox extension ──────────────────────────────────────────────────────
+console.log(`\n📦  Creating firefox-${version}.zip…`);
+zipDir(path.join(rootDir, 'dist-firefox', 'extension'), firefoxZip);
+
+// ── 4. Source archive ─────────────────────────────────────────────────────────
+console.log(`\n📦  Creating source-${version}.zip…`);
+execSync(`git archive -o "${sourceZip}" HEAD`, opts);
+
+console.log(`\n✅  All packages ready in releases/`);
+console.log(`   • releases/chrome-${version}.zip`);
+console.log(`   • releases/firefox-${version}.zip`);
+console.log(`   • releases/source-${version}.zip\n`);
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Zips the *contents* of a directory (not the directory folder itself) into a
+ * ZIP file using System.IO.Compression.ZipFile via PowerShell.
+ *
+ * @param {string} sourceDir - Absolute path to the directory to compress.
+ * @param {string} destZip   - Absolute path for the output ZIP file.
+ */
+function zipDir(sourceDir, destZip) {
+    // Normalise to forward-slashes; PowerShell accepts them and it avoids
+    // backslash-escape headaches inside the single-quoted PS string literals.
+    const src = sourceDir.replace(/\\/g, '/');
+    const dst = destZip.replace(/\\/g, '/');
+
+    const ps = [
+        `Add-Type -AssemblyName System.IO.Compression.FileSystem`,
+        `if (Test-Path '${dst}') { Remove-Item -LiteralPath '${dst}' }`,
+        `[System.IO.Compression.ZipFile]::CreateFromDirectory('${src}', '${dst}')`,
+    ].join('; ');
+
+    execSync(`powershell -NoProfile -Command "${ps}"`, { stdio: 'inherit' });
+}

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -104,7 +104,7 @@
  */
 
 .powerapps-dev-toolkit {
-    backdrop-filter: blur(10px);
+    --webkit-backdrop-filter: blur(10px);
     background: var(--pro-bg-light);
     border-radius: 12px;
     border: 1px solid var(--pro-border);
@@ -161,8 +161,8 @@
     min-height: 0;
     max-height: 0;
     overflow: hidden;
-    backface-visibility: hidden;
     -webkit-backface-visibility: hidden;
+    backface-visibility: hidden;
 }
 
 .pdt-header {
@@ -173,6 +173,7 @@
     flex-shrink: 0;
     justify-content: space-between;
     padding: 5px 6px 5px 15px;
+    -webkit-user-select: none;
     user-select: none;
     -webkit-transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
     -moz-transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
@@ -499,6 +500,7 @@ input[type="date"].pdt-input {
     align-items: center;
     color: var(--pro-text-primary);
     font-size: 14px;
+    -webkit-user-select: none;
     user-select: none;
 }
 
@@ -557,6 +559,7 @@ input[type="date"].pdt-input {
 }
 
 .pdt-multiselect-option span {
+    -webkit-user-select: none;
     user-select: none;
 }
 
@@ -846,7 +849,7 @@ input[type="date"].pdt-input {
 /* --- Dialogs (Modals) --- */
 .pdt-dialog-overlay {
     align-items: center;
-    backdrop-filter: blur(4px);
+    --webkit-backdrop-filter: blur(4px);
     background: rgba(0,0,0,0.7);
     display: flex;
     height: 100%;
@@ -1045,6 +1048,7 @@ input[type="date"].pdt-input {
     cursor: pointer;
     position: sticky;
     top: 0;
+    -webkit-user-select: none;
     user-select: none;
     z-index: 1;
     transition: background-color 0.15s ease;
@@ -1244,7 +1248,7 @@ body.pdt-col-resize-active * {
     width: 60px;
     text-align: center;
     padding: 4px 8px;
-    -moz-appearance: textfield;
+    appearance: textfield;
 }
 
 .pdt-pagination input[type=number]::-webkit-outer-spin-button,
@@ -1377,10 +1381,13 @@ body.pdt-col-resize-active * {
 }
 
 /* --- Lists --- */
-.tree-view, 
+.pdt-tree-view,
+.pdt-list {
+    padding-left: 0;
+}
+
 .pdt-list {
     list-style: none;
-    padding-left: 0;
 }
 
 .pdt-list li {
@@ -1493,6 +1500,7 @@ body.pdt-col-resize-active * {
     display: flex;
     font-size: 14px;
     gap: 8px;
+    -webkit-user-select: none;
     user-select: none;
 }
 
@@ -1720,52 +1728,52 @@ input:checked + .pdt-toggle-slider:before {
 }
 
 /* --- Inspector Tab --- */
-.tree-view {
+.pdt-tree-view {
     padding-left: 0;
 }
-.tree-item {
+.pdt-tree-item {
     border-bottom: 1px solid var(--pro-border);
 }
-.tree-child {
+.pdt-tree-child {
     padding-left: 20px;
 }
-.tree-parent.collapsed > .tree-child {
+.pdt-tree-parent.pdt-collapsed > .pdt-tree-child {
     display: none;
 }
-.tree-node-content {
+.pdt-tree-node-content {
     align-items: center;
     display: flex;
     justify-content: space-between;
     padding: 6px 5px;
     position: relative;
 }
-.tree-parent > .tree-node-content {
+.pdt-tree-parent > .pdt-tree-node-content {
     cursor: pointer;
 }
-.tree-view > .tree-item:hover > .tree-node-content {
+.pdt-tree-view > .pdt-tree-item:hover > .pdt-tree-node-content {
     background-color: var(--pro-hover-bg);
 }
-.tree-view > .tree-item > .tree-child > .tree-item:hover > .tree-node-content {
+.pdt-tree-view > .pdt-tree-item > .pdt-tree-child > .pdt-tree-item:hover > .pdt-tree-node-content {
     background-color: rgba(var(--pro-accent-rgb),0.15);
 }
-.tree-view > .tree-item > .tree-child > .tree-item > .tree-child > .tree-item:hover > .tree-node-content {
+.pdt-tree-view > .pdt-tree-item > .pdt-tree-child > .pdt-tree-item > .pdt-tree-child > .pdt-tree-item:hover > .pdt-tree-node-content {
     background-color: rgba(var(--pro-accent-rgb),0.25);
 }
-.item-details {
+.pdt-item-details {
     display: flex;
     flex-direction: column;
     gap: 2px;
 }
-.item-label {
+.pdt-item-label {
     font-size: 15px;
     font-weight: 600;
 }
-.item-logical-name {
+.pdt-item-logical-name {
     color: var(--pro-text-secondary);
     font-family: monospace;
     font-size: 12px;
 }
-.item-value {
+.pdt-item-value {
     font-family: monospace;
     max-width: 50%;
     overflow: hidden;
@@ -1773,27 +1781,27 @@ input:checked + .pdt-toggle-slider:before {
     text-overflow: ellipsis;
     white-space: nowrap;
 }
-.item-value.editable {
+.pdt-item-value.editable {
     cursor: pointer;
     display: flex;
     align-items: center;
     justify-content: flex-end;
     gap: 4px;
 }
-.item-value.editable:hover {
+.pdt-item-value.editable:hover {
     color: var(--pro-accent-light);
 }
-.item-value .edit-icon {
+.pdt-item-value .edit-icon {
     display: inline-flex;
     width: 14px;
     height: 14px;
     opacity: 0.6;
     flex-shrink: 0;
 }
-.item-value.editable:hover .edit-icon {
+.pdt-item-value.editable:hover .edit-icon {
     opacity: 1;
 }
-.tree-parent > .tree-node-content::before {
+.pdt-tree-parent > .pdt-tree-node-content::before {
     color: var(--pro-text-secondary);
     content: '▸';
     font-size: 16px;
@@ -1803,14 +1811,14 @@ input:checked + .pdt-toggle-slider:before {
     transform: translateY(-50%);
     transition: transform 0.2s ease-in-out;
 }
-.tree-parent.expanded > .tree-node-content::before {
+.pdt-tree-parent.pdt-expanded > .pdt-tree-node-content::before {
     transform: translateY(-50%) rotate(90deg);
 }
-.tree-view .copyable {
+.pdt-tree-view .copyable {
   text-underline-offset: 2px;
 }
-.tree-view .copyable:hover,
-.tree-view .copyable:focus {
+.pdt-tree-view .copyable:hover,
+.pdt-tree-view .copyable:focus {
   text-decoration: underline;
   cursor: pointer;
   outline: none;
@@ -2017,6 +2025,7 @@ input:checked + .pdt-toggle-slider:before {
     gap: 10px;
     margin-bottom: 8px;
     padding: 12px;
+    -webkit-user-select: none;
     user-select: none;
 }
 #tab-settings-list li.dragging,
@@ -3166,6 +3175,7 @@ input:checked + .pdt-toggle-slider:before {
 }
 
 .pdt-radio-label span {
+    -webkit-user-select: none;
     user-select: none;
 }
 
@@ -4265,6 +4275,7 @@ input:checked + .pdt-toggle-slider:before {
     gap: 8px;
     list-style: none;
     padding: 8px 12px;
+    -webkit-user-select: none;
     user-select: none;
 }
 
@@ -4957,6 +4968,7 @@ details[open] .pdt-details-summary {
     gap: 6px;
     list-style: none;
     padding: 6px 12px;
+    -webkit-user-select: none;
     user-select: none;
     justify-content: center;
 }
@@ -5026,5 +5038,6 @@ details[open] > .pdt-flow-scope-summary::before {
 .pdt-flow-id {
     font-family: 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
     font-size: 12px;
+    -webkit-user-select: all;
     user-select: all;
 }

--- a/src/components/AboutTab.js
+++ b/src/components/AboutTab.js
@@ -84,13 +84,20 @@ export class AboutTab extends BaseComponent {
                 </header>
                 <div class="pdt-card-body">
                     <ul class="pdt-changelog-list">
-                        <li><strong>FormJSON Handler Parsing (Form Automation):</strong> Form Automation now reads handlers from the modern <code>formjson</code> column, fixing missing handlers on forms created with the new Power Apps form designer.</li>
-                        <li><strong>Managed/Custom Badges (Form Automation):</strong> Each event handler now displays a <em>Managed</em> or <em>Custom</em> badge, making it easy to distinguish system handlers from customizable ones.</li>
-                        <li><strong>Handler Deduplication (Form Automation):</strong> Duplicate handlers across formxml and formjson sources are automatically merged.</li>
-                        <li><strong>(Form Columns):</strong> Fixed a crash when opening the Form Columns tab after impersonating a user.</li>
+                        <li><strong>Form Inspector Fix (CSS Isolation):</strong> Fixed the Form Inspector tab showing only arrows without data on Email, Template, and other forms that load the RichTextEditor control. Host page CSS no longer interferes with the tree view.</li>
+                        <li><strong>Safari CSS Compatibility:</strong> Added <code>-webkit-user-select</code> prefix across all stylesheets for full Safari and iOS Safari support.</li>
                     </ul>
                     <details class="pdt-changelog-details" style="cursor: pointer;">
-                        <summary style="cursor: pointer; user-select: none;"><strong> Version 4.2.0</strong></summary>
+                        <summary style="cursor: pointer; -webkit--webkit-user-select: none; user-select: none; -webkit-user-select: none; user-select: none;"><strong> Version 4.2.1</strong></summary>
+                        <ul class="pdt-changelog-list" style="margin-top: 0.5rem;">
+                            <li><strong>FormJSON Handler Parsing (Form Automation):</strong> Form Automation now reads handlers from the modern <code>formjson</code> column, fixing missing handlers on forms created with the new Power Apps form designer.</li>
+                            <li><strong>Managed/Custom Badges (Form Automation):</strong> Each event handler now displays a <em>Managed</em> or <em>Custom</em> badge, making it easy to distinguish system handlers from customizable ones.</li>
+                            <li><strong>Handler Deduplication (Form Automation):</strong> Duplicate handlers across formxml and formjson sources are automatically merged.</li>
+                            <li><strong>(Form Columns):</strong> Fixed a crash when opening the Form Columns tab after impersonating a user.</li>
+                        </ul>
+                    </details>
+                    <details class="pdt-changelog-details" style="cursor: pointer;">
+                        <summary style="cursor: pointer; -webkit--webkit-user-select: none; user-select: none; -webkit-user-select: none; user-select: none;"><strong> Version 4.2.0</strong></summary>
                         <ul class="pdt-changelog-list" style="margin-top: 0.5rem;">
                             <li><strong>Power Automate Flows Tab:</strong> New tab to browse, activate/deactivate, delete, and open cloud flows directly from the toolkit with solution-based filtering and flow visualization.</li>
                             <li><strong>Web Resource Editing (Automation):</strong> Form event handlers in the Automation tab now allow editing web resources directly, enabling quick script updates without leaving the toolkit.</li>
@@ -104,17 +111,17 @@ export class AboutTab extends BaseComponent {
                         </ul>
                     </details>
                     <details class="pdt-changelog-details" style="cursor: pointer; margin-top: 0.5rem;">
-                        <summary style="cursor: pointer; user-select: none;"><strong> Previous Releases</strong></summary>
+                        <summary style="cursor: pointer; -webkit-user-select: none; user-select: none;"><strong> Previous Releases</strong></summary>
                         <div style="margin-top: 1rem;">
                             <details class="pdt-changelog-details" style="cursor: pointer; margin-left: 1rem;">
-                                <summary style="cursor: pointer; user-select: none;"><strong>Version 4.1.0</strong></summary>
+                                <summary style="cursor: pointer; -webkit-user-select: none; user-select: none;"><strong>Version 4.1.0</strong></summary>
                                 <ul class="pdt-changelog-list" style="margin-top: 0.5rem;">
                                     <li>Firefox Extension: Cross-browser support with Firefox add-on alongside Chrome and Edge.</li>
                                     <li>Browser API Abstraction: Unified browser extension API layer for seamless Chrome/Edge/Firefox compatibility.</li>
                                 </ul>
                             </details>
                             <details class="pdt-changelog-details" style="cursor: pointer; margin-left: 1rem; margin-top: 0.5rem;">
-                                <summary style="cursor: pointer; user-select: none;"><strong>Version 4.0.0</strong></summary>
+                                <summary style="cursor: pointer; -webkit-user-select: none; user-select: none;"><strong>Version 4.0.0</strong></summary>
                                 <ul class="pdt-changelog-list" style="margin-top: 0.5rem;">
                                     <li>Server-Side Pagination: Handle 5000+ record queries with automatic pagination in both WebAPI Explorer and FetchXML Tester.</li>
                                     <li>Smart Value Inputs: Auto-detect attribute types (boolean dropdowns, picklists, date pickers, lookups) for easier query building.</li>
@@ -130,7 +137,7 @@ export class AboutTab extends BaseComponent {
                                 </ul>
                             </details>
                             <details class="pdt-changelog-details" style="cursor: pointer; margin-left: 1rem; margin-top: 0.5rem;">
-                                <summary style="cursor: pointer; user-select: none;"><strong>Version 3.0.0</strong></summary>
+                                <summary style="cursor: pointer; -webkit-user-select: none; user-select: none;"><strong>Version 3.0.0</strong></summary>
                                 <ul class="pdt-changelog-list" style="margin-top: 0.5rem;">
                                     <li>Solution Layers Tab: New tab to view and manage solution components with active customizations.</li>
                                     <li>Resizable Table Columns: All data tables now support column resizing.</li>
@@ -139,7 +146,7 @@ export class AboutTab extends BaseComponent {
                                 </ul>
                             </details>
                             <details class="pdt-changelog-details" style="cursor: pointer; margin-left: 1rem; margin-top: 0.5rem;">
-                                <summary style="cursor: pointer; user-select: none;"><strong>Version 2.1.0</strong></summary>
+                                <summary style="cursor: pointer; -webkit-user-select: none; user-select: none;"><strong>Version 2.1.0</strong></summary>
                                 <ul class="pdt-changelog-list" style="margin-top: 0.5rem;">
                                     <li>Minimize/Restore: Minimize button added to header, double-click header or press Ctrl/Cmd+M to minimize.</li>
                                     <li>Metadata Browser: Click column headers to sort tables by Display Name or Logical Name.</li>
@@ -147,7 +154,7 @@ export class AboutTab extends BaseComponent {
                                 </ul>
                             </details>
                             <details class="pdt-changelog-details" style="cursor: pointer; margin-left: 1rem; margin-top: 0.5rem;">
-                                <summary style="cursor: pointer; user-select: none;"><strong>Version 2.0.0</strong></summary>
+                                <summary style="cursor: pointer; -webkit-user-select: none; user-select: none;"><strong>Version 2.0.0</strong></summary>
                                 <ul class="pdt-changelog-list" style="margin-top: 0.5rem;">
                                     <li>Environment Variables: Edit and save Current Values directly in addition to Default Values.</li>
                                     <li>Environment Variables: Enhanced search to include display names and types.</li>

--- a/src/components/InspectorTab.js
+++ b/src/components/InspectorTab.js
@@ -67,8 +67,8 @@ export class InspectorTab extends BaseComponent {
             if (this.hierarchy.length === 0) {
                 container.innerHTML += `<p class='pdt-note'>${Config.MESSAGES.INSPECTOR.hierarchyLoadFailed}</p>`;
             } else {
-                const treeContainer = document.createElement('ul');
-                treeContainer.className = 'tree-view';
+                const treeContainer = document.createElement('div');
+                treeContainer.className = 'pdt-tree-view';
                 treeContainer.setAttribute('role', 'tree');
                 this.ui.treeView = treeContainer; // Cache the tree container
                 container.appendChild(treeContainer);
@@ -160,8 +160,8 @@ export class InspectorTab extends BaseComponent {
      * @private
      */
     _handleTreeClick(e) {
-        const editable = e.target.closest('.item-value.editable');
-        const nodeContent = e.target.closest('.tree-node-content');
+        const editable = e.target.closest('.pdt-item-value.editable');
+        const nodeContent = e.target.closest('.pdt-tree-node-content');
 
         // Handle editing a value
         if (editable && nodeContent) {
@@ -174,14 +174,14 @@ export class InspectorTab extends BaseComponent {
         }
 
         // Handle expanding/collapsing a parent node
-        const parentNode = e.target.closest('.tree-parent');
+        const parentNode = e.target.closest('.pdt-tree-parent');
         if (parentNode && nodeContent && parentNode.contains(nodeContent)) {
             // --- LAZY RENDERING LOGIC ---
             // If expanding for the first time, render its children.
-            if (parentNode.classList.contains('collapsed') && parentNode.dataset.rendered === 'false') {
+            if (parentNode.classList.contains('pdt-collapsed') && parentNode.dataset.rendered === 'false') {
                 const logicalName = nodeContent.dataset.logicalName;
                 const nodeData = findNodeInTree(this.hierarchy, 'logicalName', logicalName);
-                const childList = parentNode.querySelector('.tree-child');
+                const childList = parentNode.querySelector('.pdt-tree-child');
                 if (nodeData && childList) {
                     this._renderTree(childList, nodeData.children ?? []);
                     parentNode.dataset.rendered = 'true';
@@ -189,11 +189,11 @@ export class InspectorTab extends BaseComponent {
             }
             // --- END LAZY RENDERING LOGIC ---
 
-            parentNode.classList.toggle('collapsed');
-            parentNode.classList.toggle('expanded');
-            const content = parentNode.querySelector('.tree-node-content');
+            parentNode.classList.toggle('pdt-collapsed');
+            parentNode.classList.toggle('pdt-expanded');
+            const content = parentNode.querySelector('.pdt-tree-node-content');
             if (content) {
-                content.setAttribute('aria-expanded', String(parentNode.classList.contains('expanded')));
+                content.setAttribute('aria-expanded', String(parentNode.classList.contains('pdt-expanded')));
             }
         }
     }
@@ -205,7 +205,7 @@ export class InspectorTab extends BaseComponent {
      * @private
      */
     _handleMouseMove(event) {
-        const nodeContent = event.target.closest('.tree-node-content');
+        const nodeContent = event.target.closest('.pdt-tree-node-content');
         if (nodeContent === this.currentlyHoveredNode) {
             return;
         }
@@ -260,7 +260,7 @@ export class InspectorTab extends BaseComponent {
     /**
      * Renders the direct children for a given set of nodes into a parent element.
      * This is now non-recursive to support lazy loading.
-     * @param {HTMLElement} parentEl - The `<ul>` element to append children to.
+     * @param {HTMLElement} parentEl - The container element to append children to.
      * @param {Array<object>} nodes - The array of node objects to render.
      * @private
      */
@@ -268,11 +268,11 @@ export class InspectorTab extends BaseComponent {
         (nodes ?? []).forEach(node => {
             const li = this._createTreeNode(node);
             if (node.children?.length > 0) {
-                li.classList.add('tree-parent', 'collapsed');
+                li.classList.add('pdt-tree-parent', 'pdt-collapsed');
                 li.dataset.rendered = 'false';
 
-                const childList = document.createElement('ul');
-                childList.className = 'tree-child';
+                const childList = document.createElement('div');
+                childList.className = 'pdt-tree-child';
                 childList.setAttribute('role', 'group');
                 li.appendChild(childList);
             }
@@ -281,14 +281,14 @@ export class InspectorTab extends BaseComponent {
     }
 
     /**
-     * Creates a single tree node `<li>` element from a data object.
+     * Creates a single tree node element from a data object.
      * @param {object} node - The data object for the node.
-     * @returns {HTMLElement} The created `<li>` element.
+     * @returns {HTMLElement} The created element.
      * @private
      */
     _createTreeNode(node) {
-        const listItem = document.createElement('li');
-        listItem.className = 'tree-item';
+        const listItem = document.createElement('div');
+        listItem.className = 'pdt-tree-item';
 
         const valueStr = formatDisplayValue(node.value, node.editableAttr, node.controlType);
         const isEditable = !!node.editableAttr && !node.controlType?.includes('subgrid');
@@ -296,28 +296,28 @@ export class InspectorTab extends BaseComponent {
         // Omit `title` from the inline HTML – it will be set via setAttribute below to
         // avoid HTML attribute injection when valueStr contains double-quote characters.
         const valueHtml = node.value !== undefined
-            ? `<div class="item-value ${isEditable ? 'editable' : ''}">
+            ? `<div class="pdt-item-value ${isEditable ? 'editable' : ''}">
                 ${isEditable ? `<span class="edit-icon">${ICONS.edit}</span>` : ''}
                 ${escapeHtml(valueStr)}
               </div>`
             : '';
 
         listItem.innerHTML = `
-    <div class="tree-node-content"
+    <div class="pdt-tree-node-content"
          data-logical-name="${escapeHtml(node.logicalName || '')}"
          role="treeitem"
          tabindex="0"
          aria-expanded="false">
-      <div class="item-details">
-        <span class="item-label">${escapeHtml(node.label)}</span>
-        <span class="item-logical-name copyable" title="Click to copy">${escapeHtml(node.logicalName || '')}</span>
+      <div class="pdt-item-details">
+        <span class="pdt-item-label">${escapeHtml(node.label)}</span>
+        <span class="pdt-item-logical-name copyable" title="Click to copy">${escapeHtml(node.logicalName || '')}</span>
       </div>
       ${valueHtml}
     </div>`;
 
         // Set the value tooltip via DOM API so any characters in the value are safely handled.
         if (node.value !== undefined) {
-            listItem.querySelector('.item-value')?.setAttribute('title', valueStr);
+            listItem.querySelector('.pdt-item-value')?.setAttribute('title', valueStr);
         }
 
         return listItem;

--- a/src/constants/app.js
+++ b/src/constants/app.js
@@ -7,7 +7,7 @@
  * The current version number of the toolkit.
  * @type {string}
  */
-export const TOOL_VERSION = '4.2.1';
+export const TOOL_VERSION = '4.2.2';
 
 /**
  * The name of the application's author.

--- a/tests/components/InspectorTab.test.js
+++ b/tests/components/InspectorTab.test.js
@@ -146,13 +146,13 @@ describe('InspectorTab', () => {
 
         it('should render tree view container when hierarchy exists', async () => {
             const element = await component.render();
-            const treeView = element.querySelector('.tree-view');
+            const treeView = element.querySelector('.pdt-tree-view');
             expect(treeView).toBeTruthy();
         });
 
         it('should set tree view role attribute for accessibility', async () => {
             const element = await component.render();
-            const treeView = element.querySelector('.tree-view');
+            const treeView = element.querySelector('.pdt-tree-view');
             expect(treeView?.getAttribute('role')).toBe('tree');
         });
 
@@ -270,37 +270,37 @@ describe('InspectorTab', () => {
     describe('tree structure', () => {
         it('should render expandable nodes', async () => {
             const element = await component.render();
-            const treeItems = element.querySelectorAll('.tree-view li');
+            const treeItems = element.querySelectorAll('.pdt-tree-view .pdt-tree-item');
             expect(treeItems.length).toBeGreaterThan(0);
         });
 
         it('should mark parent nodes with tree-parent class', async () => {
             const element = await component.render();
-            const parentNodes = element.querySelectorAll('.tree-parent');
+            const parentNodes = element.querySelectorAll('.pdt-tree-parent');
             expect(parentNodes.length).toBeGreaterThan(0);
         });
 
         it('should mark parent nodes as collapsed initially', async () => {
             const element = await component.render();
-            const collapsedNodes = element.querySelectorAll('.tree-parent.collapsed');
+            const collapsedNodes = element.querySelectorAll('.pdt-tree-parent.pdt-collapsed');
             expect(collapsedNodes.length).toBeGreaterThan(0);
         });
 
         it('should set data-rendered to false for lazy loading', async () => {
             const element = await component.render();
-            const parentNode = element.querySelector('.tree-parent');
+            const parentNode = element.querySelector('.pdt-tree-parent');
             expect(parentNode?.dataset.rendered).toBe('false');
         });
 
-        it('should render tree-child ul elements for parent nodes', async () => {
+        it('should render tree-child elements for parent nodes', async () => {
             const element = await component.render();
-            const childLists = element.querySelectorAll('.tree-child');
+            const childLists = element.querySelectorAll('.pdt-tree-child');
             expect(childLists.length).toBeGreaterThan(0);
         });
 
         it('should set role=group on child lists', async () => {
             const element = await component.render();
-            const childList = element.querySelector('.tree-child');
+            const childList = element.querySelector('.pdt-tree-child');
             expect(childList?.getAttribute('role')).toBe('group');
         });
     });
@@ -308,60 +308,60 @@ describe('InspectorTab', () => {
     describe('_renderTree', () => {
         it('should append tree nodes to parent element', async () => {
             const element = await component.render();
-            const treeView = element.querySelector('.tree-view');
+            const treeView = element.querySelector('.pdt-tree-view');
             expect(treeView?.children.length).toBeGreaterThan(0);
         });
 
         it('should handle empty nodes array', async () => {
-            const parentEl = document.createElement('ul');
+            const parentEl = document.createElement('div');
             component._renderTree(parentEl, []);
             expect(parentEl.children.length).toBe(0);
         });
 
         it('should handle null nodes array', async () => {
-            const parentEl = document.createElement('ul');
+            const parentEl = document.createElement('div');
             component._renderTree(parentEl, null);
             expect(parentEl.children.length).toBe(0);
         });
 
         it('should handle undefined nodes array', async () => {
-            const parentEl = document.createElement('ul');
+            const parentEl = document.createElement('div');
             component._renderTree(parentEl, undefined);
             expect(parentEl.children.length).toBe(0);
         });
 
         it('should create tree-item elements', async () => {
-            const parentEl = document.createElement('ul');
+            const parentEl = document.createElement('div');
             component._renderTree(parentEl, [{ label: 'Test', logicalName: 'test' }]);
-            expect(parentEl.querySelector('.tree-item')).toBeTruthy();
+            expect(parentEl.querySelector('.pdt-tree-item')).toBeTruthy();
         });
 
         it('should not add tree-parent class for leaf nodes', async () => {
-            const parentEl = document.createElement('ul');
+            const parentEl = document.createElement('div');
             component._renderTree(parentEl, [{ label: 'Leaf', logicalName: 'leaf' }]);
-            expect(parentEl.querySelector('.tree-parent')).toBeFalsy();
+            expect(parentEl.querySelector('.pdt-tree-parent')).toBeFalsy();
         });
 
         it('should add tree-parent class for nodes with children', async () => {
-            const parentEl = document.createElement('ul');
+            const parentEl = document.createElement('div');
             component._renderTree(parentEl, [{
                 label: 'Parent',
                 logicalName: 'parent',
                 children: [{ label: 'Child', logicalName: 'child' }]
             }]);
-            expect(parentEl.querySelector('.tree-parent')).toBeTruthy();
+            expect(parentEl.querySelector('.pdt-tree-parent')).toBeTruthy();
         });
     });
 
     describe('_createTreeNode', () => {
-        it('should create an li element', () => {
+        it('should create a div element', () => {
             const node = component._createTreeNode({ label: 'Test', logicalName: 'test' });
-            expect(node.tagName).toBe('LI');
+            expect(node.tagName).toBe('DIV');
         });
 
         it('should add tree-item class', () => {
             const node = component._createTreeNode({ label: 'Test', logicalName: 'test' });
-            expect(node.classList.contains('tree-item')).toBe(true);
+            expect(node.classList.contains('pdt-tree-item')).toBe(true);
         });
 
         it('should include logical name in data attribute', () => {
@@ -380,12 +380,12 @@ describe('InspectorTab', () => {
                 logicalName: 'test',
                 value: 'Test Value'
             });
-            expect(node.querySelector('.item-value')).toBeTruthy();
+            expect(node.querySelector('.pdt-item-value')).toBeTruthy();
         });
 
         it('should not render value element when value is undefined', () => {
             const node = component._createTreeNode({ label: 'Test', logicalName: 'test' });
-            expect(node.querySelector('.item-value')).toBeFalsy();
+            expect(node.querySelector('.pdt-item-value')).toBeFalsy();
         });
 
         it('should add editable class when editableAttr is present', () => {
@@ -397,7 +397,7 @@ describe('InspectorTab', () => {
                 editableAttr: mockAttr,
                 controlType: 'standard'
             });
-            expect(node.querySelector('.item-value.editable')).toBeTruthy();
+            expect(node.querySelector('.pdt-item-value.editable')).toBeTruthy();
         });
 
         it('should not add editable class for subgrid controls', () => {
@@ -409,12 +409,12 @@ describe('InspectorTab', () => {
                 editableAttr: mockAttr,
                 controlType: 'subgrid'
             });
-            expect(node.querySelector('.item-value.editable')).toBeFalsy();
+            expect(node.querySelector('.pdt-item-value.editable')).toBeFalsy();
         });
 
         it('should include copyable class on logical name span', () => {
             const node = component._createTreeNode({ label: 'Test', logicalName: 'test' });
-            expect(node.querySelector('.item-logical-name.copyable')).toBeTruthy();
+            expect(node.querySelector('.pdt-item-logical-name.copyable')).toBeTruthy();
         });
 
         it('should set role=treeitem on node content', () => {
@@ -429,7 +429,7 @@ describe('InspectorTab', () => {
 
         it('should set aria-expanded=false initially', () => {
             const node = component._createTreeNode({ label: 'Test', logicalName: 'test' });
-            const content = node.querySelector('.tree-node-content');
+            const content = node.querySelector('.pdt-tree-node-content');
             expect(content?.getAttribute('aria-expanded')).toBe('false');
         });
     });
@@ -470,21 +470,21 @@ describe('InspectorTab', () => {
         });
 
         it('should toggle collapsed/expanded on parent node click', () => {
-            const parentNode = element.querySelector('.tree-parent.collapsed');
-            const nodeContent = parentNode.querySelector('.tree-node-content');
+            const parentNode = element.querySelector('.pdt-tree-parent.pdt-collapsed');
+            const nodeContent = parentNode.querySelector('.pdt-tree-node-content');
 
             const clickEvent = new MouseEvent('click', { bubbles: true });
             Object.defineProperty(clickEvent, 'target', { value: nodeContent });
 
             component._handleTreeClick(clickEvent);
 
-            expect(parentNode.classList.contains('expanded')).toBe(true);
-            expect(parentNode.classList.contains('collapsed')).toBe(false);
+            expect(parentNode.classList.contains('pdt-expanded')).toBe(true);
+            expect(parentNode.classList.contains('pdt-collapsed')).toBe(false);
         });
 
         it('should update aria-expanded when toggling', () => {
-            const parentNode = element.querySelector('.tree-parent.collapsed');
-            const nodeContent = parentNode.querySelector('.tree-node-content');
+            const parentNode = element.querySelector('.pdt-tree-parent.pdt-collapsed');
+            const nodeContent = parentNode.querySelector('.pdt-tree-node-content');
 
             const clickEvent = new MouseEvent('click', { bubbles: true });
             Object.defineProperty(clickEvent, 'target', { value: nodeContent });
@@ -495,9 +495,9 @@ describe('InspectorTab', () => {
         });
 
         it('should perform lazy rendering on first expansion', () => {
-            const parentNode = element.querySelector('.tree-parent[data-rendered="false"]');
-            const nodeContent = parentNode.querySelector('.tree-node-content');
-            const childList = parentNode.querySelector('.tree-child');
+            const parentNode = element.querySelector('.pdt-tree-parent[data-rendered="false"]');
+            const nodeContent = parentNode.querySelector('.pdt-tree-node-content');
+            const childList = parentNode.querySelector('.pdt-tree-child');
 
             // Initially empty
             expect(childList.children.length).toBe(0);
@@ -511,8 +511,8 @@ describe('InspectorTab', () => {
         });
 
         it('should not render children again on subsequent clicks', () => {
-            const parentNode = element.querySelector('.tree-parent');
-            const nodeContent = parentNode.querySelector('.tree-node-content');
+            const parentNode = element.querySelector('.pdt-tree-parent');
+            const nodeContent = parentNode.querySelector('.pdt-tree-node-content');
 
             // First click - expand
             const clickEvent1 = new MouseEvent('click', { bubbles: true });
@@ -524,7 +524,7 @@ describe('InspectorTab', () => {
             Object.defineProperty(clickEvent2, 'target', { value: nodeContent });
             component._handleTreeClick(clickEvent2);
 
-            expect(parentNode.classList.contains('collapsed')).toBe(true);
+            expect(parentNode.classList.contains('pdt-collapsed')).toBe(true);
         });
 
         it('should not throw when clicking non-tree elements', () => {
@@ -559,7 +559,7 @@ describe('InspectorTab', () => {
         });
 
         it('should set currentlyHoveredNode when hovering over node', () => {
-            const nodeContent = element.querySelector('.tree-node-content');
+            const nodeContent = element.querySelector('.pdt-tree-node-content');
 
             const moveEvent = new MouseEvent('mousemove', { bubbles: true });
             Object.defineProperty(moveEvent, 'target', { value: nodeContent });
@@ -571,7 +571,7 @@ describe('InspectorTab', () => {
 
         it('should clear highlight when moving away from node', () => {
             // First hover
-            const nodeContent = element.querySelector('.tree-node-content');
+            const nodeContent = element.querySelector('.pdt-tree-node-content');
             const moveEvent1 = new MouseEvent('mousemove', { bubbles: true });
             Object.defineProperty(moveEvent1, 'target', { value: nodeContent });
             component._handleMouseMove(moveEvent1);
@@ -585,7 +585,7 @@ describe('InspectorTab', () => {
         });
 
         it('should not re-process same node on subsequent moves', () => {
-            const nodeContent = element.querySelector('.tree-node-content');
+            const nodeContent = element.querySelector('.pdt-tree-node-content');
 
             const moveEvent = new MouseEvent('mousemove', { bubbles: true });
             Object.defineProperty(moveEvent, 'target', { value: nodeContent });
@@ -598,7 +598,7 @@ describe('InspectorTab', () => {
         });
 
         it('should handle nodes without logicalName', () => {
-            const nodeContent = element.querySelector('.tree-node-content');
+            const nodeContent = element.querySelector('.pdt-tree-node-content');
             delete nodeContent.dataset.logicalName;
 
             const moveEvent = new MouseEvent('mousemove', { bubbles: true });
@@ -613,7 +613,7 @@ describe('InspectorTab', () => {
             controlEl.setAttribute('data-control-name', 'name_control');
             document.body.appendChild(controlEl);
 
-            const nodeContent = element.querySelector('.tree-node-content');
+            const nodeContent = element.querySelector('.pdt-tree-node-content');
             const moveEvent = new MouseEvent('mousemove', { bubbles: true });
             Object.defineProperty(moveEvent, 'target', { value: nodeContent });
 
@@ -876,13 +876,13 @@ describe('InspectorTab', () => {
 
         it('should have aria-expanded on expandable nodes', async () => {
             const element = await component.render();
-            const nodeContent = element.querySelector('.tree-node-content');
+            const nodeContent = element.querySelector('.pdt-tree-node-content');
             expect(nodeContent?.hasAttribute('aria-expanded')).toBe(true);
         });
 
         it('should have tabindex for keyboard navigation', async () => {
             const element = await component.render();
-            const nodeContent = element.querySelector('.tree-node-content');
+            const nodeContent = element.querySelector('.pdt-tree-node-content');
             expect(nodeContent?.getAttribute('tabindex')).toBe('0');
         });
     });
@@ -923,7 +923,7 @@ describe('InspectorTab', () => {
             const element = await component.render();
 
             // Two tabs with children at the top level
-            expect(element.querySelectorAll('.tree-parent').length).toBe(2);
+            expect(element.querySelectorAll('.pdt-tree-parent').length).toBe(2);
         });
 
         it('should handle full lifecycle: render, postRender, destroy', async () => {
@@ -979,8 +979,8 @@ describe('InspectorTab', () => {
         });
 
         it('should open editor when clicking on editable value', () => {
-            const editableValue = element.querySelector('.item-value.editable');
-            const nodeContent = element.querySelector('.tree-node-content');
+            const editableValue = element.querySelector('.pdt-item-value.editable');
+            const nodeContent = element.querySelector('.pdt-tree-node-content');
 
             const clickEvent = new MouseEvent('click', { bubbles: true });
             Object.defineProperty(clickEvent, 'target', { value: editableValue });
@@ -992,7 +992,7 @@ describe('InspectorTab', () => {
 
         it('should not open editor when nodeContent is missing', () => {
             const orphanEditable = document.createElement('div');
-            orphanEditable.className = 'item-value editable';
+            orphanEditable.className = 'pdt-item-value editable';
             document.body.appendChild(orphanEditable);
 
             const clickEvent = new MouseEvent('click', { bubbles: true });
@@ -1017,10 +1017,10 @@ describe('InspectorTab', () => {
             const element2 = await component.render();
             document.body.appendChild(element2);
 
-            const editableValue = element2.querySelector('.item-value');
+            const editableValue = element2.querySelector('.pdt-item-value');
             if (editableValue) {
                 editableValue.classList.add('editable'); // Force editable class
-                const nodeContent = element2.querySelector('.tree-node-content');
+                const nodeContent = element2.querySelector('.pdt-tree-node-content');
 
                 const clickEvent = new MouseEvent('click', { bubbles: true });
                 Object.defineProperty(clickEvent, 'target', { value: editableValue });
@@ -1046,9 +1046,9 @@ describe('InspectorTab', () => {
             document.body.appendChild(element2);
             component.postRender(element2);
 
-            const parentNode = element2.querySelector('.tree-parent.collapsed');
-            const nodeContent = parentNode.querySelector('.tree-node-content');
-            const childList = parentNode.querySelector('.tree-child');
+            const parentNode = element2.querySelector('.pdt-tree-parent.pdt-collapsed');
+            const nodeContent = parentNode.querySelector('.pdt-tree-node-content');
+            const childList = parentNode.querySelector('.pdt-tree-child');
 
             expect(childList.children.length).toBe(0);
 
@@ -1057,7 +1057,7 @@ describe('InspectorTab', () => {
             component._handleTreeClick(clickEvent);
 
             expect(parentNode.dataset.rendered).toBe('true');
-            expect(parentNode.classList.contains('expanded')).toBe(true);
+            expect(parentNode.classList.contains('pdt-expanded')).toBe(true);
         });
 
         it('should handle node without children array gracefully', async () => {
@@ -1072,7 +1072,7 @@ describe('InspectorTab', () => {
             document.body.appendChild(element2);
 
             // Should not throw
-            expect(element2.querySelector('.tree-item')).toBeTruthy();
+            expect(element2.querySelector('.pdt-tree-item')).toBeTruthy();
         });
     });
 
@@ -1101,7 +1101,7 @@ describe('InspectorTab', () => {
             controlEl.setAttribute('data-lp-id', 'form|lpid_control|field');
             document.body.appendChild(controlEl);
 
-            const nodeContent = element.querySelector('.tree-node-content');
+            const nodeContent = element.querySelector('.pdt-tree-node-content');
             const moveEvent = new MouseEvent('mousemove', { bubbles: true });
             Object.defineProperty(moveEvent, 'target', { value: nodeContent });
 
@@ -1134,7 +1134,7 @@ describe('InspectorTab', () => {
             controlEl.setAttribute('aria-label', 'aria_control');
             document.body.appendChild(controlEl);
 
-            const nodeContent = element.querySelector('.tree-node-content');
+            const nodeContent = element.querySelector('.pdt-tree-node-content');
             const moveEvent = new MouseEvent('mousemove', { bubbles: true });
             Object.defineProperty(moveEvent, 'target', { value: nodeContent });
 
@@ -1155,7 +1155,7 @@ describe('InspectorTab', () => {
             document.body.appendChild(element);
             component.postRender(element);
 
-            const nodeContent = element.querySelector('.tree-node-content');
+            const nodeContent = element.querySelector('.pdt-tree-node-content');
             const moveEvent = new MouseEvent('mousemove', { bubbles: true });
             Object.defineProperty(moveEvent, 'target', { value: nodeContent });
 
@@ -1181,7 +1181,7 @@ describe('InspectorTab', () => {
             document.body.appendChild(element);
             component.postRender(element);
 
-            const nodeContent = element.querySelector('.tree-node-content');
+            const nodeContent = element.querySelector('.pdt-tree-node-content');
             const moveEvent = new MouseEvent('mousemove', { bubbles: true });
             Object.defineProperty(moveEvent, 'target', { value: nodeContent });
 
@@ -1205,7 +1205,7 @@ describe('InspectorTab', () => {
             document.body.appendChild(element);
             component.postRender(element);
 
-            const nodeContent = element.querySelector('.tree-node-content');
+            const nodeContent = element.querySelector('.pdt-tree-node-content');
             const moveEvent = new MouseEvent('mousemove', { bubbles: true });
             Object.defineProperty(moveEvent, 'target', { value: nodeContent });
 
@@ -1232,7 +1232,7 @@ describe('InspectorTab', () => {
             document.body.appendChild(element);
             component.postRender(element);
 
-            const nodeContent = element.querySelector('.tree-node-content');
+            const nodeContent = element.querySelector('.pdt-tree-node-content');
             const moveEvent = new MouseEvent('mousemove', { bubbles: true });
             Object.defineProperty(moveEvent, 'target', { value: nodeContent });
 
@@ -1444,12 +1444,12 @@ describe('InspectorTab', () => {
 
         it('should handle node with null logicalName', () => {
             const node = component._createTreeNode({ label: 'Test', logicalName: null });
-            expect(node.querySelector('.tree-node-content')).toBeTruthy();
+            expect(node.querySelector('.pdt-tree-node-content')).toBeTruthy();
         });
 
         it('should handle node with undefined logicalName', () => {
             const node = component._createTreeNode({ label: 'Test' });
-            expect(node.querySelector('.tree-node-content')).toBeTruthy();
+            expect(node.querySelector('.pdt-tree-node-content')).toBeTruthy();
         });
 
         it('should handle node with controlType containing subgrid', () => {
@@ -1461,7 +1461,7 @@ describe('InspectorTab', () => {
                 editableAttr: mockAttr,
                 controlType: 'subgrid_related'
             });
-            expect(node.querySelector('.item-value.editable')).toBeFalsy();
+            expect(node.querySelector('.pdt-item-value.editable')).toBeFalsy();
         });
 
         it('should render edit icon for editable fields', () => {
@@ -1491,7 +1491,7 @@ describe('InspectorTab', () => {
                 logicalName: 'test_field',
                 value: 'Long value text'
             });
-            const valueEl = node.querySelector('.item-value');
+            const valueEl = node.querySelector('.pdt-item-value');
             expect(valueEl?.getAttribute('title')).toBeDefined();
         });
     });
@@ -1566,7 +1566,7 @@ describe('InspectorTab', () => {
             ]);
 
             const element = await component.render();
-            const treeItems = element.querySelectorAll('.tree-view > .tree-item');
+            const treeItems = element.querySelectorAll('.pdt-tree-view > .pdt-tree-item');
 
             expect(treeItems.length).toBe(3);
         });
@@ -1614,8 +1614,8 @@ describe('InspectorTab', () => {
             document.body.appendChild(element);
             component.postRender(element);
 
-            const parentNode = element.querySelector('.tree-parent.collapsed');
-            const nodeContent = parentNode.querySelector('.tree-node-content');
+            const parentNode = element.querySelector('.pdt-tree-parent.pdt-collapsed');
+            const nodeContent = parentNode.querySelector('.pdt-tree-node-content');
 
             const clickEvent = new MouseEvent('click', { bubbles: true });
             Object.defineProperty(clickEvent, 'target', { value: nodeContent });
@@ -1636,15 +1636,15 @@ describe('InspectorTab', () => {
             document.body.appendChild(element);
             component.postRender(element);
 
-            const parentNode = element.querySelector('.tree-parent.collapsed');
-            const childList = parentNode.querySelector('.tree-child');
+            const parentNode = element.querySelector('.pdt-tree-parent.pdt-collapsed');
+            const childList = parentNode.querySelector('.pdt-tree-child');
 
             // Remove the child list
             if (childList) {
                 childList.remove();
             }
 
-            const nodeContent = parentNode.querySelector('.tree-node-content');
+            const nodeContent = parentNode.querySelector('.pdt-tree-node-content');
             const clickEvent = new MouseEvent('click', { bubbles: true });
             Object.defineProperty(clickEvent, 'target', { value: nodeContent });
 
@@ -1661,7 +1661,7 @@ describe('InspectorTab', () => {
                 value: 12345
             });
 
-            const valueEl = node.querySelector('.item-value');
+            const valueEl = node.querySelector('.pdt-item-value');
             expect(valueEl).toBeTruthy();
         });
 
@@ -1672,7 +1672,7 @@ describe('InspectorTab', () => {
                 value: true
             });
 
-            expect(node.querySelector('.item-value')).toBeTruthy();
+            expect(node.querySelector('.pdt-item-value')).toBeTruthy();
         });
 
         it('should handle null values', () => {
@@ -1682,7 +1682,7 @@ describe('InspectorTab', () => {
                 value: null
             });
 
-            expect(node.querySelector('.item-value')).toBeTruthy();
+            expect(node.querySelector('.pdt-item-value')).toBeTruthy();
         });
 
         it('should handle object values', () => {
@@ -1692,7 +1692,7 @@ describe('InspectorTab', () => {
                 value: { key: 'value' }
             });
 
-            expect(node.querySelector('.item-value')).toBeTruthy();
+            expect(node.querySelector('.pdt-item-value')).toBeTruthy();
         });
     });
 
@@ -1731,7 +1731,7 @@ describe('InspectorTab', () => {
                 const newCopyable = document.createElement('span');
                 newCopyable.className = 'copyable';
                 newCopyable.textContent = 'test-clipboard-text';
-                element.querySelector('.tree-view')?.appendChild(newCopyable);
+                element.querySelector('.pdt-tree-view')?.appendChild(newCopyable);
             }
 
             const targetCopyable = element.querySelector('.copyable');
@@ -1771,7 +1771,7 @@ describe('InspectorTab', () => {
             const copyable = document.createElement('span');
             copyable.className = 'copyable';
             copyable.textContent = 'test-value';
-            element.querySelector('.tree-view')?.appendChild(copyable);
+            element.querySelector('.pdt-tree-view')?.appendChild(copyable);
 
             // The copyToClipboard mock should work normally in this test
             // We just verify the handler can be called without issues
@@ -1835,7 +1835,7 @@ describe('InspectorTab', () => {
             const copyable = document.createElement('span');
             copyable.className = 'copyable';
             copyable.textContent = 'navigator-clipboard-test';
-            element.querySelector('.tree-view')?.appendChild(copyable);
+            element.querySelector('.pdt-tree-view')?.appendChild(copyable);
 
             // Save original and replace copyToClipboard to return undefined
             const writeTextMock = vi.fn().mockResolvedValue(undefined);


### PR DESCRIPTION
- Form Inspector Fix (CSS Isolation): Fixed the Form Inspector tab showing only arrows without data on Email, Template, and other forms that load the RichTextEditor control. Host page CSS no longer interferes with the tree view.
- Safari CSS Compatibility: Added -webkit-user-select prefix across all stylesheets for full Safari and iOS Safari support.